### PR TITLE
request to connect to another connector(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then go to [localhost:7770](http://localhost:7770) in your browser.
 
 ## TODOs
 
+- [ ] send a request(invitation) to connect to the connector via the moneyd-gui interface
 - [ ] CORS
 - [x] live update on receiver page
 - [ ] live update on balances


### PR DESCRIPTION
I think it would be nice to be able to send a request (invitation) to connect to another connector(s) via the moneyd-gui interface.
For example: send to everyone or send to a specific connector.
After the connector confirms the request, everyone on their side chooses the role, enters (if necessary) additional data and presses to confirm, after which all the settings are automatically added to the configuration file (s). Well, or almost so.